### PR TITLE
Add support for displaying arrivals

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -4,6 +4,7 @@
     "requests_max_per_day": 1000,
     "stop_ids": "900170004",
     "request_hours": 3,
+    "data_sources": "departures",
     "remove_string": "",
     "ignore_destination": "",
     "screen_rotation": 0,

--- a/hafas_event.py
+++ b/hafas_event.py
@@ -1,0 +1,126 @@
+import re
+from datetime import datetime, timedelta
+
+from helper import Helper
+from hosted import CONFIG
+from mapping import CATEGORY_MAPPING, COLOUR_MAPPING
+
+REMOVE = re.escape(CONFIG["remove_string"].strip())
+
+
+class HAFASEvent:
+    def __init__(self, data):
+        self.json = data
+        self.duplicate = False
+        self.follow = None
+
+        for product in data["Product"]:
+            if product.get("name") and product.get("catCode"):
+                self.symbol = product["name"]
+                self.category = product["catCode"]
+                self.operator = product.get("operatorCode", None)
+                self.icon = product.get("icon", None)
+                break
+        else:
+            self.symbol = ""
+            self.category = -1
+            self.operator = None
+            self.icon = None
+
+        if CONFIG["api_provider"] in CATEGORY_MAPPING:
+            self.category_icon = CATEGORY_MAPPING[CONFIG["api_provider"]].get(
+                str(self.category), ""
+            )
+        else:
+            self.category_icon = ""
+
+        scheduled = datetime.strptime(
+            data["date"] + " " + data["time"], "%Y-%m-%d %H:%M:%S"
+        )
+        if "rtTime" in data and "rtDate" in data:
+            self.realtime = datetime.strptime(
+                data["rtDate"] + " " + data["rtTime"], "%Y-%m-%d %H:%M:%S"
+            )
+            diff = self.realtime - scheduled
+            self.delay = int(diff.total_seconds() / 60)
+        else:
+            self.realtime = scheduled
+            self.delay = 0
+
+    def __lt__(self, other):
+        assert isinstance(other, HAFASEvent)
+        return self.realtime < other.realtime
+
+    def _clean(self, key):
+        return re.sub(
+            "^(" + REMOVE + "[- ])",
+            "",
+            re.sub(
+                "(\(" + REMOVE + "\))$", "", self.json[key].strip(), flags=re.IGNORECASE
+            ),
+            flags=re.IGNORECASE,
+        ).strip()
+
+    @property
+    def destination(self):
+        return self._clean("direction")
+
+    @property
+    def ignore_event(self):
+        if CONFIG["ignore_destination"] and re.match(
+            CONFIG["ignore_destination"], self.destination
+        ):
+            return True
+        return False
+
+    @property
+    def line_colour(self):
+        font_r, font_g, font_b = (1, 1, 1)
+        if not CONFIG["coloured_lines"]:
+            r, g, b = (0.3, 0.3, 0.3)
+        else:
+            provider = CONFIG["api_provider"]
+            if (
+                provider in COLOUR_MAPPING
+                and self.operator in COLOUR_MAPPING[provider]
+                and self.symbol in COLOUR_MAPPING[provider][self.operator]
+            ):
+                r, g, b = COLOUR_MAPPING[provider][self.operator][self.symbol]
+            elif self.icon is not None:
+                r, g, b = Helper.hex2rgb(self.icon["backgroundColor"]["hex"][1:])
+                font_r, font_g, font_b = Helper.hex2rgb(
+                    self.icon["foregroundColor"]["hex"][1:]
+                )
+            else:
+                name_hash = md5(self.json["name"]).hexdigest()
+                r, g, b = Helper.hex2rgb(name_hash[:6])
+                h, s, v = Helper.rgb2hsv(r * 255, g * 255, b * 255)
+                if v > 0.75:
+                    font_r, font_g, font_b = (0, 0, 0)
+        return {
+            "background_colour": {
+                "r": r,
+                "g": g,
+                "b": b,
+            },
+            "font_colour": {
+                "r": font_r,
+                "g": font_g,
+                "b": font_b,
+            },
+        }
+
+    @property
+    def stop(self):
+        return self._clean("stop")
+
+    @property
+    def platform(self):
+        if "platform" in self.json:
+            return "{} {}".format(
+                self.json["platform"].get("type", ""),
+                self.json["platform"].get("text", ""),
+            ).strip()
+        if "track" in self.json:
+            return self.json["track"]
+        return ""

--- a/hafas_event.py
+++ b/hafas_event.py
@@ -14,6 +14,8 @@ class HAFASEvent:
         self.duplicate = False
         self.follow = None
 
+        self.id = data["JourneyDetailRef"]["ref"]
+
         for product in data["Product"]:
             if product.get("name") and product.get("catCode"):
                 self.symbol = product["name"]
@@ -63,7 +65,17 @@ class HAFASEvent:
 
     @property
     def destination(self):
-        return self._clean("direction")
+        if "direction" in self.json:
+            return self._clean("direction")
+        else:
+            return None
+
+    @property
+    def origin(self):
+        if "origin" in self.json:
+            return self._clean("origin")
+        else:
+            return None
 
     @property
     def ignore_event(self):

--- a/hafas_event.py
+++ b/hafas_event.py
@@ -54,28 +54,28 @@ class HAFASEvent:
         return self.realtime < other.realtime
 
     def _clean(self, key):
-        return re.sub(
-            "^(" + REMOVE + "[- ])",
-            "",
-            re.sub(
-                "(\(" + REMOVE + "\))$", "", self.json[key].strip(), flags=re.IGNORECASE
-            ),
-            flags=re.IGNORECASE,
-        ).strip()
+        if key not in self.json:
+            return None
+        else:
+            return re.sub(
+                "^(" + REMOVE + "[- ])",
+                "",
+                re.sub(
+                    "(\(" + REMOVE + "\))$",
+                    "",
+                    self.json[key].strip(),
+                    flags=re.IGNORECASE,
+                ),
+                flags=re.IGNORECASE,
+            ).strip()
 
     @property
     def destination(self):
-        if "direction" in self.json:
-            return self._clean("direction")
-        else:
-            return None
+        return self._clean("direction")
 
     @property
     def origin(self):
-        if "origin" in self.json:
-            return self._clean("origin")
-        else:
-            return None
+        return self._clean("origin")
 
     @property
     def ignore_event(self):

--- a/hafas_fetcher.py
+++ b/hafas_fetcher.py
@@ -40,6 +40,7 @@ class HAFASFetcher:
             )
         else:
             url = API_MAPPING[CONFIG["api_provider"]].format(
+                endpoint="departureBoard",
                 stop=stop_id,
                 minutes=CONFIG["request_hours"] * 60,
                 key=key,

--- a/hafas_fetcher.py
+++ b/hafas_fetcher.py
@@ -1,0 +1,111 @@
+import json
+from itertools import islice
+
+from requests import get
+
+from hafas_event import HAFASEvent
+from helper import Helper, log
+from hosted import CONFIG
+from mapping import API_MAPPING
+
+
+class HAFASFetcher:
+    def __init__(self):
+        self.departures = []
+
+    def fetch_and_parse(self, stop_id):
+        stop_info = self._fetch(stop_id)
+        departures = []
+        for dep in stop_info["Departure"]:
+            departures.append(HAFASEvent(dep))
+        departures = sorted(departures)
+        for n, dep in enumerate(departures):
+            for follow in islice(departures, n + 1, None):
+                if dep.symbol == follow.symbol and (
+                    (dep.platform != "" and dep.platform == follow.platform)
+                    or (dep.platform == "" and dep.destination == follow.destination)
+                ):
+                    dep.follow = follow
+                    break
+        self.departures.extend(departures)
+
+    def _fetch(self, stop_id):
+        key = CONFIG["api_key"].strip()
+
+        if key.startswith("http://") or key.startswith("https://"):
+            key = key.rstrip("/")
+            url = "{prefix}/{stop}.json".format(
+                prefix=key,
+                stop=stop_id,
+            )
+        else:
+            url = API_MAPPING[CONFIG["api_provider"]].format(
+                stop=stop_id,
+                minutes=CONFIG["request_hours"] * 60,
+                key=key,
+            )
+        log(
+            "Requesting {stop} info from {url}".format(
+                stop=stop_id,
+                url=url,
+            )
+        )
+        r = get(url)
+        r.raise_for_status()
+        return r.json()
+
+    def sort_and_deduplicate(self):
+        departures = sorted(self.departures)
+        for n, dep in enumerate(departures):
+            for follow in islice(departures, n + 1, None):
+                if (
+                    dep.destination == follow.destination
+                    and dep.symbol == follow.symbol
+                    and (
+                        (
+                            dep.stop != follow.stop
+                            and abs(
+                                Helper.to_unixtimestamp(dep.realtime)
+                                - Helper.to_unixtimestamp(follow.realtime)
+                            )
+                            < 120
+                        )
+                        or (
+                            dep.stop == follow.stop
+                            and abs(
+                                Helper.to_unixtimestamp(dep.realtime)
+                                - Helper.to_unixtimestamp(follow.realtime)
+                            )
+                            < 10
+                        )
+                    )
+                ):
+                    dep.duplicate = True
+                    break
+        self.departures = [dep for dep in departures if not dep.duplicate]
+
+    def write_json(self):
+        log("writing {} departures to json".format(len(self.departures)))
+        out = []
+        for dep in self.departures:
+            departure = {
+                "category": dep.category,
+                "direction": dep.destination,
+                "icon": dep.category_icon,
+                "operator": dep.operator,
+                "platform": dep.platform,
+                "stop": dep.stop,
+                "symbol": dep.symbol,
+                "time": dep.realtime.strftime("%H:%M"),
+                "timestamp": Helper.to_unixtimestamp(dep.realtime),
+                "next_timestamp": Helper.to_unixtimestamp(dep.follow.realtime)
+                if dep.follow
+                else 0,
+                "next_time": dep.follow.realtime.strftime("%H:%M")
+                if dep.follow
+                else "",
+            }
+            departure.update(dep.line_colour)
+            out.append(departure)
+        with file("departures.json", "wb") as f:
+            f.write(json.dumps(out, ensure_ascii=False).encode("utf8"))

--- a/hafas_fetcher.py
+++ b/hafas_fetcher.py
@@ -107,5 +107,5 @@ class HAFASFetcher:
             }
             departure.update(dep.line_colour)
             out.append(departure)
-        with file("departures.json", "wb") as f:
+        with file("events.json", "wb") as f:
             f.write(json.dumps(out, ensure_ascii=False).encode("utf8"))

--- a/hafas_fetcher.py
+++ b/hafas_fetcher.py
@@ -76,9 +76,10 @@ class HAFASFetcher:
             )
 
             payload = self._fetch_url(stop_id, url)
-            for label in ["Departure", "Arrival"]:
-                if label in payload:
-                    data[label] = payload[label]
+            if not self.data_sources == "arrivals":
+                data["Departure"] = payload["Departure"]
+            if not self.data_sources == "departures":
+                data["Arrival"] = payload["Arrival"]
         else:
             url = lambda ep: API_MAPPING[CONFIG["api_provider"]].format(
                 endpoint=ep,

--- a/helper.py
+++ b/helper.py
@@ -1,4 +1,11 @@
+from sys import stderr
 from time import mktime
+
+
+def log(something):
+    if not isinstance(something, str):
+        something = repr(something)
+    stderr.write("[HAFAS service] {}\n".format(something))
 
 
 class Helper:

--- a/mapping.py
+++ b/mapping.py
@@ -5,8 +5,8 @@ COLOUR_MAPPING = {
 }
 
 API_MAPPING = {
-    "rmv": "https://www.rmv.de/hapi/departureBoard?id={stop}&duration={minutes}&format=json&accessId={key}",
-    "vbb-test": "https://vbb.demo.hafas.de/fahrinfo/restproxy/2.32/departureBoard?id={stop}&duration={minutes}&format=json&accessId={key}",
+    "rmv": "https://www.rmv.de/hapi/{endpoint}?id={stop}&duration={minutes}&format=json&accessId={key}",
+    "vbb-test": "https://vbb.demo.hafas.de/fahrinfo/restproxy/2.32/{endpoint}?id={stop}&duration={minutes}&format=json&accessId={key}",
 }
 
 CATEGORY_MAPPING = {

--- a/node.json
+++ b/node.json
@@ -26,7 +26,7 @@
         "placeholder": "5555555-555555-5555-5555-555555"
     }, {
         "title": "HAFAS stop id(s)",
-        "ui_width": 8,
+        "ui_width": 4,
         "name": "stop_ids",
         "type": "string",
         "default": "3016471",
@@ -38,6 +38,17 @@
         "type": "integer",
         "default": 4900,
         "hint": "maximum number of requests done to API (per device and day) - will get ignored if using a caching server"
+    }, {
+        "title": "API Data sources",
+        "ui_width": 4,
+        "name": "data_sources",
+        "type": "select",
+        "default": "departures",
+        "options": [
+            ["departures", "Show only departures at each stop"],
+            ["arrivals", "Show only arrivals at each stop"],
+            ["both", "Show departures and terminating arrivals at each stop"]
+        ]
     }, {
         "title": "Display Options",
         "type": "section",

--- a/node.lua
+++ b/node.lua
@@ -1,14 +1,14 @@
 util.init_hosted()
 
 local json = require "json"
-local departures = {}
+local events = {}
 local rotate_before = nil
 local transform = nil
 
 gl.setup(NATIVE_WIDTH, NATIVE_HEIGHT)
 
-util.file_watch("departures.json", function(content)
-    departures = json.decode(content)
+util.file_watch("events.json", function(content)
+    events = json.decode(content)
 end)
 
 local white = resource.create_colored_texture(1,1,1,1)
@@ -50,7 +50,7 @@ local function draw(real_width, real_height)
     local line_height = CONFIG.line_height
     local margin_bottom = CONFIG.line_height * 0.2
 
-    for idx, dep in ipairs(departures) do
+    for idx, dep in ipairs(events) do
         if dep.timestamp > now_for_fade - fadeout then
             if now_for_fade > dep.timestamp then
                 y = (y - line_height - margin_bottom) / fadeout * (now_for_fade - dep.timestamp)
@@ -58,7 +58,7 @@ local function draw(real_width, real_height)
         end
     end
 
-    for idx, dep in ipairs(departures) do
+    for idx, dep in ipairs(events) do
         if dep.timestamp > now_for_fade - fadeout then
             if y < 0 and dep.timestamp >= now_for_fade then
                 y = 0
@@ -257,7 +257,7 @@ local function draw(real_width, real_height)
                 end
                 x = x + 110
 
-                -- time of departure
+                -- time of event
                 local space_for_time = icon_size * 3.5
                 local time_width = CONFIG.font:width(time, icon_size)
                 CONFIG.font:write(

--- a/node.lua
+++ b/node.lua
@@ -71,6 +71,14 @@ local function draw(real_width, real_height)
             local platform = ""
             local x = 0
 
+            local heading = dep.direction
+            local preposition = "von"
+
+            if not dep.departure then
+               heading = "Ankunft von " .. dep.direction
+               preposition = "an"
+            end
+
             if remaining < 0 then
                 time = "In der Vergangenheit"
                 if dep.next_timestamp > 10 then
@@ -98,13 +106,13 @@ local function draw(real_width, real_height)
             end
 
             if string.match(CONFIG.stop_ids, ',') then
-                platform = "von " .. dep.stop
+                platform = preposition .. " " .. dep.stop
                 if dep.platform ~= "" then
                     platform = platform .. ", " .. dep.platform
                 end
             else
                 if dep.platform ~= "" then
-                    platform = "von " .. dep.platform
+                    platform = preposition .. " " .. dep.platform
                 end
             end
             if remaining < 11 then
@@ -165,7 +173,7 @@ local function draw(real_width, real_height)
                 CONFIG.font:write(
                     x + 170,
                     text_y,
-                    dep.direction,
+                    heading,
                     text_upper_size,
                     1, 1, 1, 1
                 )
@@ -274,7 +282,7 @@ local function draw(real_width, real_height)
                 CONFIG.font:write(
                     x,
                     text_y,
-                    dep.direction,
+                    heading,
                     text_upper_size,
                     1, 1, 1,1
                 )

--- a/service
+++ b/service
@@ -38,6 +38,7 @@ def main():
     while True:
         try:
             stops = CONFIG["stop_ids"].split(",")
+            data_sources = CONFIG["data_sources"]
             hafas = HAFASFetcher()
             for stop in stops:
                 hafas.fetch_and_parse(stop)
@@ -49,8 +50,10 @@ def main():
             ):
                 idle(15)
             else:
+                requests_per_stop = 2 if data_sources == "both" else 1
+                requests_count = len(stops) * requests_per_stop
                 sleep_time = max(
-                    86400 / (CONFIG["requests_max_per_day"] / len(stops)),
+                    86400 / (CONFIG["requests_max_per_day"] / request_count),
                     30,
                 )
 

--- a/service
+++ b/service
@@ -1,32 +1,18 @@
 #!/usr/bin/env python
-import json
-import re
-import time
 import traceback
-from datetime import datetime, timedelta
-from hashlib import md5
-from itertools import islice
-from sys import stderr
+from datetime import datetime
 from time import sleep
 from time import time as timestamp
 
 from pytz import timezone, utc
-from requests import get
 
-from helper import Helper
+from hafas_fetcher import HAFASFetcher
+from helper import Helper, log
 from hosted import CONFIG, DEVICE, NODE
-from mapping import API_MAPPING, CATEGORY_MAPPING, COLOUR_MAPPING
 
 CONFIG.restart_on_update()
 
 TIMEZONE = "Europe/Berlin"
-REMOVE = re.escape(CONFIG["remove_string"].strip())
-
-
-def log(something):
-    if not isinstance(something, str):
-        something = repr(something)
-    stderr.write("[HAFAS service] {}\n".format(something))
 
 
 def _now():
@@ -44,226 +30,6 @@ def idle(seconds):
     while timestamp() < timeout:
         NODE["/time"](Helper.to_unixtimestamp(_now()))
         sleep(1)
-
-
-class HAFASDeparture:
-    def __init__(self, departure):
-        self.json = departure
-        self.duplicate = False
-        self.follow = None
-
-        for product in departure["Product"]:
-            if product.get("name") and product.get("catCode"):
-                self.symbol = product["name"]
-                self.category = product["catCode"]
-                self.operator = product.get("operatorCode", None)
-                self.icon = product.get("icon", None)
-                break
-        else:
-            self.symbol = ""
-            self.category = -1
-            self.operator = None
-            self.icon = None
-
-        if CONFIG["api_provider"] in CATEGORY_MAPPING:
-            self.category_icon = CATEGORY_MAPPING[CONFIG["api_provider"]].get(
-                str(self.category), ""
-            )
-        else:
-            self.category_icon = ""
-
-        scheduled = datetime.strptime(
-            departure["date"] + " " + departure["time"], "%Y-%m-%d %H:%M:%S"
-        )
-        if "rtTime" in departure and "rtDate" in departure:
-            self.departure = datetime.strptime(
-                departure["rtDate"] + " " + departure["rtTime"], "%Y-%m-%d %H:%M:%S"
-            )
-            diff = self.departure - scheduled
-            self.delay = int(diff.total_seconds() / 60)
-        else:
-            self.departure = scheduled
-            self.delay = 0
-
-    def __lt__(self, other):
-        assert isinstance(other, HAFASDeparture)
-        return self.departure < other.departure
-
-    def _clean(self, key):
-        return re.sub(
-            "^(" + REMOVE + "[- ])",
-            "",
-            re.sub(
-                "(\(" + REMOVE + "\))$",
-                "",
-                self.json[key].strip(),
-                flags=re.IGNORECASE
-            ),
-            flags=re.IGNORECASE,
-        ).strip()
-
-    @property
-    def destination(self):
-        return self._clean("direction")
-
-    @property
-    def ignore_departure(self):
-        if CONFIG["ignore_destination"] and re.match(
-            CONFIG["ignore_destination"], direction
-        ):
-            return True
-        return False
-
-    @property
-    def line_colour(self):
-        font_r, font_g, font_b = (1, 1, 1)
-        if not CONFIG["coloured_lines"]:
-            r, g, b = (0.3, 0.3, 0.3)
-        else:
-            provider = CONFIG["api_provider"]
-            if (
-                provider in COLOUR_MAPPING
-                and self.operator in COLOUR_MAPPING[provider]
-                and self.symbol in COLOUR_MAPPING[provider][self.operator]
-            ):
-                r, g, b = COLOUR_MAPPING[provider][self.operator][self.symbol]
-            elif self.icon is not None:
-                r, g, b = Helper.hex2rgb(self.icon["backgroundColor"]["hex"][1:])
-                font_r, font_g, font_b = Helper.hex2rgb(
-                    self.icon["foregroundColor"]["hex"][1:]
-                )
-            else:
-                name_hash = md5(self.json["name"]).hexdigest()
-                r, g, b = Helper.hex2rgb(name_hash[:6])
-                h, s, v = Helper.rgb2hsv(r * 255, g * 255, b * 255)
-                if v > 0.75:
-                    font_r, font_g, font_b = (0, 0, 0)
-        return {
-            "background_colour": {
-                "r": r,
-                "g": g,
-                "b": b,
-            },
-            "font_colour": {
-                "r": font_r,
-                "g": font_g,
-                "b": font_b,
-            },
-        }
-
-    @property
-    def stop(self):
-        return self._clean("stop")
-
-    @property
-    def platform(self):
-        if "platform" in self.json:
-            return "{} {}".format(self.json["platform"].get("type", ""), self.json["platform"].get("text", "")).strip()
-        if "track" in self.json:
-            return self.json["track"]
-        return ""
-
-
-class HAFASFetcher:
-    def __init__(self):
-        self.departures = []
-
-    def fetch_and_parse(self, stop_id):
-        stop_info = self._fetch(stop_id)
-        departures = []
-        for dep in stop_info["Departure"]:
-            departures.append(HAFASDeparture(dep))
-        departures = sorted(departures)
-        for n, dep in enumerate(departures):
-            for follow in islice(departures, n + 1, None):
-                if dep.symbol == follow.symbol and (
-                    (dep.platform != "" and dep.platform == follow.platform)
-                    or (dep.platform == "" and dep.destination == follow.destination)
-                ):
-                    dep.follow = follow
-                    break
-        self.departures.extend(departures)
-
-    def _fetch(self, stop_id):
-        key = CONFIG["api_key"].strip()
-
-        if key.startswith("http://") or key.startswith("https://"):
-            key = key.rstrip("/")
-            url = "{prefix}/{stop}.json".format(
-                prefix=key,
-                stop=stop_id,
-            )
-        else:
-            url = API_MAPPING[CONFIG["api_provider"]].format(
-                stop=stop_id,
-                minutes=CONFIG["request_hours"] * 60,
-                key=key,
-            )
-        log(
-            "Requesting {stop} info from {url}".format(
-                stop=stop_id,
-                url=url,
-            )
-        )
-        r = get(url)
-        r.raise_for_status()
-        return r.json()
-
-    def sort_and_deduplicate(self):
-        departures = sorted(self.departures)
-        for n, dep in enumerate(departures):
-            for follow in islice(departures, n + 1, None):
-                if (
-                    dep.destination == follow.destination
-                    and dep.symbol == follow.symbol
-                    and (
-                        (
-                            dep.stop != follow.stop
-                            and abs(
-                                Helper.to_unixtimestamp(dep.departure)
-                                - Helper.to_unixtimestamp(follow.departure)
-                            )
-                            < 120
-                        )
-                        or (
-                            dep.stop == follow.stop
-                            and abs(
-                                Helper.to_unixtimestamp(dep.departure)
-                                - Helper.to_unixtimestamp(follow.departure)
-                            )
-                            < 10
-                        )
-                    )
-                ):
-                    dep.duplicate = True
-                    break
-        self.departures = [dep for dep in departures if not dep.duplicate]
-
-    def write_json(self):
-        log("writing {} departures to json".format(len(self.departures)))
-        out = []
-        for dep in self.departures:
-            departure = {
-                "category": dep.category,
-                "direction": dep.destination,
-                "icon": dep.category_icon,
-                "operator": dep.operator,
-                "platform": dep.platform,
-                "stop": dep.stop,
-                "symbol": dep.symbol,
-                "time": dep.departure.strftime("%H:%M"),
-                "timestamp": Helper.to_unixtimestamp(dep.departure),
-                "next_timestamp": Helper.to_unixtimestamp(dep.follow.departure)
-                if dep.follow
-                else 0,
-                "next_time": dep.follow.departure.strftime("%H:%M")
-                if dep.follow
-                else "",
-            }
-            departure.update(dep.line_colour)
-            out.append(departure)
-        with file("departures.json", "wb") as f:
-            f.write(json.dumps(out, ensure_ascii=False).encode("utf8"))
 
 
 def main():
@@ -291,7 +57,7 @@ def main():
                 idle(sleep_time)
         except Exception:
             traceback.print_exc()
-            time.sleep(30)
+            sleep(30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors the HAFAS-related classes and adds new functionality to show arrivals instead of (or as well as) departures in the display table, using the `arrivalBoard` HAFAS endpoint. A new configuration option, `data_sources`, controls whether only departures, only arrivals, or both are displayed in the table. In the case where both are displayed, then arrivals are only shown where they terminate at the configured stop (implemented by checking for arrivals which have no matching departure).

When using a cache server as a data source instead of a provider API, the cache server will aggregate departure and arrival data into a single JSON file, which can then be fetched by the info beamer script in a single HTTP request.